### PR TITLE
feat(data): Add IntoData for easier initialization 

### DIFF
--- a/crates/snapbox/src/assert/mod.rs
+++ b/crates/snapbox/src/assert/mod.rs
@@ -9,6 +9,7 @@ use anstream::stderr;
 use std::io::stderr;
 
 use crate::filter::{Filter as _, FilterNewlines, FilterPaths, FilterRedactions};
+use crate::IntoData;
 
 pub use action::Action;
 pub use action::DEFAULT_ACTION_ENV;
@@ -70,9 +71,9 @@ impl Assert {
     /// Assert::new().eq_(actual, file!["output.txt"]);
     /// ```
     #[track_caller]
-    pub fn eq_(&self, actual: impl Into<crate::Data>, expected: impl Into<crate::Data>) {
-        let expected = expected.into();
-        let actual = actual.into();
+    pub fn eq_(&self, actual: impl IntoData, expected: impl IntoData) {
+        let expected = expected.into_data();
+        let actual = actual.into_data();
         if let Err(err) = self.try_eq(Some(&"In-memory"), actual, expected) {
             err.panic();
         }

--- a/crates/snapbox/src/cmd.rs
+++ b/crates/snapbox/src/cmd.rs
@@ -3,6 +3,8 @@
 #[cfg(feature = "color")]
 use anstream::panic;
 
+use crate::IntoData;
+
 /// Process spawning for testing of non-interactive commands
 #[derive(Debug)]
 pub struct Command {
@@ -243,8 +245,8 @@ impl Command {
     ///     .assert()
     ///     .stdout_eq("42");
     /// ```
-    pub fn stdin(mut self, stream: impl Into<crate::Data>) -> Self {
-        self.stdin = Some(stream.into());
+    pub fn stdin(mut self, stream: impl IntoData) -> Self {
+        self.stdin = Some(stream.into_data());
         self
     }
 
@@ -623,8 +625,8 @@ impl OutputAssert {
     ///     .stdout_eq_(file!["stdout.log"]);
     /// ```
     #[track_caller]
-    pub fn stdout_eq_(self, expected: impl Into<crate::Data>) -> Self {
-        let expected = expected.into();
+    pub fn stdout_eq_(self, expected: impl IntoData) -> Self {
+        let expected = expected.into_data();
         self.stdout_eq_inner(expected)
     }
 
@@ -745,8 +747,8 @@ impl OutputAssert {
     ///     .stderr_eq_(file!["stderr.log"]);
     /// ```
     #[track_caller]
-    pub fn stderr_eq_(self, expected: impl Into<crate::Data>) -> Self {
-        let expected = expected.into();
+    pub fn stderr_eq_(self, expected: impl IntoData) -> Self {
+        let expected = expected.into_data();
         self.stderr_eq_inner(expected)
     }
 

--- a/crates/snapbox/src/cmd.rs
+++ b/crates/snapbox/src/cmd.rs
@@ -702,7 +702,7 @@ impl OutputAssert {
 
     #[track_caller]
     fn stdout_eq_inner(self, expected: crate::Data) -> Self {
-        let actual = crate::Data::from(self.output.stdout.as_slice());
+        let actual = self.output.stdout.as_slice().into_data();
         if let Err(err) = self.config.try_eq(Some(&"stdout"), actual, expected) {
             err.panic();
         }
@@ -824,7 +824,7 @@ impl OutputAssert {
 
     #[track_caller]
     fn stderr_eq_inner(self, expected: crate::Data) -> Self {
-        let actual = crate::Data::from(self.output.stderr.as_slice());
+        let actual = self.output.stderr.as_slice().into_data();
         if let Err(err) = self.config.try_eq(Some(&"stderr"), actual, expected) {
             err.panic();
         }

--- a/crates/snapbox/src/data/mod.rs
+++ b/crates/snapbox/src/data/mod.rs
@@ -630,6 +630,13 @@ impl<'s> From<&'s str> for Data {
     }
 }
 
+impl From<Inline> for super::Data {
+    fn from(inline: Inline) -> Self {
+        let trimmed = inline.trimmed();
+        super::Data::text(trimmed).with_source(inline)
+    }
+}
+
 #[cfg(feature = "detect-encoding")]
 fn is_binary(data: &[u8]) -> bool {
     match content_inspector::inspect(data) {

--- a/crates/snapbox/src/data/runtime.rs
+++ b/crates/snapbox/src/data/runtime.rs
@@ -373,8 +373,8 @@ impl PathRuntime {
 mod tests {
     use super::*;
     use crate::assert_eq;
+    use crate::prelude::*;
     use crate::str;
-    use crate::ToDebug as _;
 
     #[test]
     fn test_format_patch() {

--- a/crates/snapbox/src/data/source.rs
+++ b/crates/snapbox/src/data/source.rs
@@ -114,7 +114,7 @@ impl Inline {
         data.coerce_to(format)
     }
 
-    fn trimmed(&self) -> String {
+    pub(crate) fn trimmed(&self) -> String {
         let mut data = self.data;
         if data.contains('\n') {
             if data.starts_with('\n') {
@@ -150,13 +150,6 @@ fn trim_indent(text: &str) -> String {
 impl std::fmt::Display for Inline {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.position.fmt(f)
-    }
-}
-
-impl From<Inline> for super::Data {
-    fn from(inline: Inline) -> Self {
-        let trimmed = inline.trimmed();
-        super::Data::text(trimmed).with_source(inline)
     }
 }
 

--- a/crates/snapbox/src/data/source.rs
+++ b/crates/snapbox/src/data/source.rs
@@ -112,13 +112,6 @@ impl Inline {
         data.coerce_to(format)
     }
 
-    /// Remove default [`filters`][crate::filter] from this `expected` result
-    pub fn raw(self) -> super::Data {
-        let mut data: super::Data = self.into();
-        data.filters = super::FilterSet::empty().newlines();
-        data
-    }
-
     fn trimmed(&self) -> String {
         let mut data = self.data;
         if data.contains('\n') {

--- a/crates/snapbox/src/data/source.rs
+++ b/crates/snapbox/src/data/source.rs
@@ -100,6 +100,8 @@ impl Inline {
     /// assert_eq!(expected.format(), snapbox::data::DataFormat::Json);
     /// # }
     /// ```
+    // #[deprecated(since = "0.5.11", note = "Replaced with `IntoData::is`")]   // can't deprecate
+    // because trait will always be preferred
     pub fn is(self, format: super::DataFormat) -> super::Data {
         let data: super::Data = self.into();
         data.is(format)

--- a/crates/snapbox/src/lib.rs
+++ b/crates/snapbox/src/lib.rs
@@ -130,6 +130,11 @@ pub type Result<T, E = assert::Error> = std::result::Result<T, E>;
 #[deprecated(since = "0.5.11", note = "Replaced with `assert::Error`")]
 pub type Error = assert::Error;
 
+/// Easier access to common traits
+pub mod prelude {
+    pub use crate::ToDebug;
+}
+
 /// Check if a value is the same as an expected value
 ///
 /// When the content is text, newlines are normalized.

--- a/crates/snapbox/src/lib.rs
+++ b/crates/snapbox/src/lib.rs
@@ -113,6 +113,7 @@ pub mod harness;
 pub use assert::Action;
 pub use assert::Assert;
 pub use data::Data;
+pub use data::IntoData;
 pub use data::ToDebug;
 pub use filter::RedactedValue;
 pub use filter::Redactions;
@@ -132,6 +133,7 @@ pub type Error = assert::Error;
 
 /// Easier access to common traits
 pub mod prelude {
+    pub use crate::IntoData;
     pub use crate::ToDebug;
 }
 

--- a/crates/trycmd/src/runner.rs
+++ b/crates/trycmd/src/runner.rs
@@ -15,6 +15,7 @@ use rayon::prelude::*;
 use snapbox::data::DataFormat;
 use snapbox::dir::FileType;
 use snapbox::filter::{Filter as _, FilterNewlines, FilterPaths, FilterRedactions};
+use snapbox::IntoData;
 
 #[derive(Debug)]
 pub(crate) struct Runner {
@@ -584,12 +585,12 @@ impl Output {
         self.spawn.status = SpawnStatus::Ok;
         self.stdout = Some(Stream {
             stream: Stdio::Stdout,
-            content: output.stdout.into(),
+            content: output.stdout.into_data(),
             status: StreamStatus::Ok,
         });
         self.stderr = Some(Stream {
             stream: Stdio::Stderr,
-            content: output.stderr.into(),
+            content: output.stderr.into_data(),
             status: StreamStatus::Ok,
         });
         self


### PR DESCRIPTION
This has everything from #292 except the removal of `Into<Data>` which is a breaking change meant to make it easier to discover what types `IntoData` can be used on.