### PR TITLE
fix(filter): Revert filter renames 

### DIFF
--- a/crates/snapbox/CHANGELOG.md
+++ b/crates/snapbox/CHANGELOG.md
@@ -17,8 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Deprecated `OutputAssert::stderr_matches(expected, actual)` in favor of `OutputAssert::stderr_eq_(actual, expected)`
 - Deprecated `data::Data::normalize` in favor of `filter::Filter::filter`
 - Deprecated `data::Normalize::normalize` in favor of `filter::Filter::filter`
-- Deprecated `data::NormalizeNewlines` in favor of `filter::FilterNewlines`
-- Deprecated `data::NormalizePaths` in favor of `filter::FilterPaths`
+- Deprecated `data::NormalizeNewlines` in favor of `filter::NormalizeNewlines`
+- Deprecated `data::NormalizePaths` in favor of `filter::NormalizePaths`
 - Deprecated `data::NormalizeMatches` in favor of `filter::FilterRedactions`
 - Deprecated `data::Substitutions` in favor of `filter::Redactions`
 - Deprecated `path` feature / mod in favor of `dir` feature / mod

--- a/crates/snapbox/CHANGELOG.md
+++ b/crates/snapbox/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+### Compatibility
+
+- Deprecated `Assert::eq(expected, actual)` in favor of `Assert::eq_(actual, expected.raw())`
+- Deprecated `Assert::matches(expected, actual)` in favor of `Assert::eq_(actual, expected)`
+- Deprecated `OutputAssert::stdout_eq(expected, actual)` in favor of `OutputAssert::stdout_eq_(actual, expected.raw())`
+- Deprecated `OutputAssert::stdout_matches(expected, actual)` in favor of `OutputAssert::stdout_eq_(actual, expected)`
+- Deprecated `OutputAssert::stderr_eq(expected, actual)` in favor of `OutputAssert::stderr_eq_(actual, expected.raw())`
+- Deprecated `OutputAssert::stderr_matches(expected, actual)` in favor of `OutputAssert::stderr_eq_(actual, expected)`
+- Deprecated `data::Data::normalize` in favor of `filter::Filter::filter`
+- Deprecated `data::Normalize::normalize` in favor of `filter::Filter::filter`
+- Deprecated `data::NormalizeNewlines` in favor of `filter::FilterNewlines`
+- Deprecated `data::NormalizePaths` in favor of `filter::FilterPaths`
+- Deprecated `data::NormalizeMatches` in favor of `filter::FilterRedactions`
+- Deprecated `data::Substitutions` in favor of `filter::Redactions`
+- Deprecated `path` feature / mod in favor of `dir` feature / mod
+- Deprecated `path::PathFixture` in favor of `dir::DirRoot`
+- Deprecated `Error` in favor of `assert::Error`
+- Deprecated `Result` in favor of `assert::Result`
+- Deprecated `Action` in favor of `assert::Action`
+- Deprecated `DEFAULT_ACTION_ENV` in favor of `assert::DEFAULT_ACTION_ENV`
+- Deprecated `utils::normalize_lines` in favor of `filter::normalize_lines`
+- Deprecated `utils::normalize_paths` in favor of `filter::normalize_paths`
+- Deprecated `utils::normalize_text`
+
+### Features
+
+- Add `Assert::eq_(actual, expected)`
+- Add `OutputAssert::stdout_eq_(actual, expected)`
+- Add `OutputAssert::stderr_eq_(actual, expected)`
+- Add `assert_data_eq!(actual, expected)`
+- Add `prelude` for easier access to `IntoData`, `IntoJson`, and `ToDebug`
+- Add `IntoData` for easier data conversions
+- Add `IntoJson` for easier data conversions
+- Add `Data::raw` to disable filters on expected values
+- Add `Harness::with_assert` for greater customization
+- Add `Assert::try_eq` for non-panicking asserts
+- Add `Assert::selected_action` to see whats chosen
+
 ## [0.5.10] - 2024-05-15
 
 ## [0.5.9] - 2024-03-13

--- a/crates/snapbox/src/assert/mod.rs
+++ b/crates/snapbox/src/assert/mod.rs
@@ -8,7 +8,7 @@ use anstream::stderr;
 #[cfg(not(feature = "color"))]
 use std::io::stderr;
 
-use crate::filter::{Filter as _, FilterNewlines, FilterPaths, FilterRedactions};
+use crate::filter::{Filter as _, FilterRedactions, NormalizeNewlines, NormalizePaths};
 use crate::IntoData;
 
 pub use action::Action;
@@ -175,7 +175,7 @@ impl Assert {
         mut expected: crate::Data,
     ) -> (crate::Data, crate::Data) {
         if expected.filters.is_newlines_set() {
-            expected = FilterNewlines.filter(expected);
+            expected = NormalizeNewlines.filter(expected);
         }
 
         // On `expected` being an error, make a best guess
@@ -183,10 +183,10 @@ impl Assert {
         actual = actual.coerce_to(format);
 
         if self.normalize_paths && expected.filters.is_paths_set() {
-            actual = FilterPaths.filter(actual);
+            actual = NormalizePaths.filter(actual);
         }
         if expected.filters.is_newlines_set() {
-            actual = FilterNewlines.filter(actual);
+            actual = NormalizeNewlines.filter(actual);
         }
         if expected.filters.is_redaction_set() {
             actual = FilterRedactions::new(&self.substitutions, &expected).filter(actual);

--- a/crates/snapbox/src/data/normalize.rs
+++ b/crates/snapbox/src/data/normalize.rs
@@ -4,19 +4,19 @@ use super::Data;
 
 pub use crate::filter::Filter as Normalize;
 
-#[deprecated(since = "0.5.11", note = "Replaced with `filter::FilterNewlines")]
+#[deprecated(since = "0.5.11", note = "Replaced with `filter::NormalizeNewlines")]
 pub struct NormalizeNewlines;
 impl Normalize for NormalizeNewlines {
     fn normalize(&self, data: Data) -> Data {
-        crate::filter::FilterNewlines.normalize(data)
+        crate::filter::NormalizeNewlines.normalize(data)
     }
 }
 
-#[deprecated(since = "0.5.11", note = "Replaced with `filter::FilterPaths")]
+#[deprecated(since = "0.5.11", note = "Replaced with `filter::NormalizePaths")]
 pub struct NormalizePaths;
 impl Normalize for NormalizePaths {
     fn normalize(&self, data: Data) -> Data {
-        crate::filter::FilterPaths.normalize(data)
+        crate::filter::NormalizePaths.normalize(data)
     }
 }
 

--- a/crates/snapbox/src/dir/diff.rs
+++ b/crates/snapbox/src/dir/diff.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "dir")]
-use crate::filter::{Filter as _, FilterNewlines, FilterPaths, FilterRedactions};
+use crate::filter::{Filter as _, FilterRedactions, NormalizeNewlines, NormalizePaths};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum PathDiff {
@@ -78,9 +78,9 @@ impl PathDiff {
                         crate::Data::try_read_from(&actual_path, None).map_err(Self::Failure)?;
 
                     let expected =
-                        FilterNewlines.filter(crate::Data::read_from(&expected_path, None));
+                        NormalizeNewlines.filter(crate::Data::read_from(&expected_path, None));
 
-                    actual = FilterNewlines.filter(actual.coerce_to(expected.intended_format()));
+                    actual = NormalizeNewlines.filter(actual.coerce_to(expected.intended_format()));
 
                     if expected != actual {
                         return Err(Self::ContentMismatch {
@@ -154,14 +154,14 @@ impl PathDiff {
                         crate::Data::try_read_from(&actual_path, None).map_err(Self::Failure)?;
 
                     let expected =
-                        FilterNewlines.filter(crate::Data::read_from(&expected_path, None));
+                        NormalizeNewlines.filter(crate::Data::read_from(&expected_path, None));
 
                     actual = actual.coerce_to(expected.intended_format());
                     if normalize_paths {
-                        actual = FilterPaths.filter(actual);
+                        actual = NormalizePaths.filter(actual);
                     }
                     actual = FilterRedactions::new(substitutions, &expected)
-                        .filter(FilterNewlines.filter(actual));
+                        .filter(NormalizeNewlines.filter(actual));
 
                     if expected != actual {
                         return Err(Self::ContentMismatch {

--- a/crates/snapbox/src/filter/mod.rs
+++ b/crates/snapbox/src/filter/mod.rs
@@ -23,8 +23,8 @@ pub trait Filter {
     }
 }
 
-pub struct FilterNewlines;
-impl Filter for FilterNewlines {
+pub struct NormalizeNewlines;
+impl Filter for NormalizeNewlines {
     fn normalize(&self, data: Data) -> Data {
         let source = data.source;
         let filters = data.filters;
@@ -64,8 +64,8 @@ fn normalize_lines_chars(data: impl Iterator<Item = char>) -> impl Iterator<Item
     normalize_line_endings::normalized(data)
 }
 
-pub struct FilterPaths;
-impl Filter for FilterPaths {
+pub struct NormalizePaths;
+impl Filter for NormalizePaths {
     fn normalize(&self, data: Data) -> Data {
         let source = data.source;
         let filters = data.filters;

--- a/crates/snapbox/src/filter/test.rs
+++ b/crates/snapbox/src/filter/test.rs
@@ -10,9 +10,9 @@ use super::*;
 fn json_normalize_paths_and_lines() {
     let json = json!({"name": "John\\Doe\r\n"});
     let data = Data::json(json);
-    let data = FilterPaths.filter(data);
+    let data = NormalizePaths.filter(data);
     assert_eq!(Data::json(json!({"name": "John/Doe\r\n"})), data);
-    let data = FilterNewlines.filter(data);
+    let data = NormalizeNewlines.filter(data);
     assert_eq!(Data::json(json!({"name": "John/Doe\n"})), data);
 }
 
@@ -26,7 +26,7 @@ fn json_normalize_obj_paths_and_lines() {
         }
     });
     let data = Data::json(json);
-    let data = FilterPaths.filter(data);
+    let data = NormalizePaths.filter(data);
     let assert = json!({
         "person": {
             "name": "John/Doe\r\n",
@@ -34,7 +34,7 @@ fn json_normalize_obj_paths_and_lines() {
         }
     });
     assert_eq!(Data::json(assert), data);
-    let data = FilterNewlines.filter(data);
+    let data = NormalizeNewlines.filter(data);
     let assert = json!({
         "person": {
             "name": "John/Doe\n",
@@ -49,10 +49,10 @@ fn json_normalize_obj_paths_and_lines() {
 fn json_normalize_array_paths_and_lines() {
     let json = json!({"people": ["John\\Doe\r\n", "Jo\\hn\r\n"]});
     let data = Data::json(json);
-    let data = FilterPaths.filter(data);
+    let data = NormalizePaths.filter(data);
     let paths = json!({"people": ["John/Doe\r\n", "Jo/hn\r\n"]});
     assert_eq!(Data::json(paths), data);
-    let data = FilterNewlines.filter(data);
+    let data = NormalizeNewlines.filter(data);
     let new_lines = json!({"people": ["John/Doe\n", "Jo/hn\n"]});
     assert_eq!(Data::json(new_lines), data);
 }
@@ -69,7 +69,7 @@ fn json_normalize_array_obj_paths_and_lines() {
         ]
     });
     let data = Data::json(json);
-    let data = FilterPaths.filter(data);
+    let data = NormalizePaths.filter(data);
     let paths = json!({
         "people": [
             {
@@ -79,7 +79,7 @@ fn json_normalize_array_obj_paths_and_lines() {
         ]
     });
     assert_eq!(Data::json(paths), data);
-    let data = FilterNewlines.filter(data);
+    let data = NormalizeNewlines.filter(data);
     let new_lines = json!({
         "people": [
             {

--- a/crates/trycmd/src/runner.rs
+++ b/crates/trycmd/src/runner.rs
@@ -14,7 +14,7 @@ use std::io::stderr;
 use rayon::prelude::*;
 use snapbox::data::DataFormat;
 use snapbox::dir::FileType;
-use snapbox::filter::{Filter as _, FilterNewlines, FilterPaths, FilterRedactions};
+use snapbox::filter::{Filter as _, FilterRedactions, NormalizeNewlines, NormalizePaths};
 use snapbox::IntoData;
 
 #[derive(Debug)]
@@ -738,7 +738,7 @@ impl Stream {
         if content.format() != DataFormat::Text {
             self.status = StreamStatus::Failure("Unable to convert underlying Data to Text".into());
         }
-        self.content = FilterNewlines.filter(FilterPaths.filter(content));
+        self.content = NormalizeNewlines.filter(NormalizePaths.filter(content));
         self
     }
 

--- a/crates/trycmd/src/schema.rs
+++ b/crates/trycmd/src/schema.rs
@@ -2,7 +2,7 @@
 //!
 //! [`OneShot`] is the top-level item in the `cmd.toml` files.
 
-use snapbox::filter::{Filter as _, FilterNewlines, FilterPaths};
+use snapbox::filter::{Filter as _, NormalizeNewlines, NormalizePaths};
 use std::collections::BTreeMap;
 use std::collections::VecDeque;
 
@@ -40,8 +40,8 @@ impl TryCmd {
                     let stdout_path = path.with_extension("stdout");
                     let stdout = if stdout_path.exists() {
                         Some(
-                            FilterNewlines.filter(
-                                FilterPaths
+                            NormalizeNewlines.filter(
+                                NormalizePaths
                                     .filter(crate::Data::read_from(&stdout_path, Some(is_binary))),
                             ),
                         )
@@ -55,8 +55,8 @@ impl TryCmd {
                     let stderr_path = path.with_extension("stderr");
                     let stderr = if stderr_path.exists() {
                         Some(
-                            FilterNewlines.filter(
-                                FilterPaths
+                            NormalizeNewlines.filter(
+                                NormalizePaths
                                     .filter(crate::Data::read_from(&stderr_path, Some(is_binary))),
                             ),
                         )


### PR DESCRIPTION
`FilterPaths` as a concept doesn't make sense.  What the filter is doing
is normalizing paths.

ditto for newlines