### PR TITLE
feat(trycmd): Support `echo text | command`

### DIFF
--- a/crates/trycmd/src/bin/bin-fixture.rs
+++ b/crates/trycmd/src/bin/bin-fixture.rs
@@ -5,6 +5,12 @@ use std::io::Write;
 use std::process;
 
 fn run() -> Result<(), Box<dyn Error>> {
+    if env::var("lines-from-stdin").as_deref() == Ok("1") {
+        for line in std::io::stdin().lines() {
+            println!("read line from stdin: {}", line.unwrap());
+        }
+    }
+
     if let Ok(text) = env::var("stdout") {
         println!("{}", text);
     }

--- a/crates/trycmd/tests/cmd/echo-stdin.trycmd
+++ b/crates/trycmd/tests/cmd/echo-stdin.trycmd
@@ -1,0 +1,6 @@
+```
+$ echo "hello" "second argument" | \
+> lines-from-stdin=1 bin-fixture
+read line from stdin: hello second argument
+
+```


### PR DESCRIPTION
```console
$ echo "hello" "second argument" | lines-from-stdin=1 bin-fixture
read line from stdin: hello second argument

```

Rather than attempting to do the common case and facing its security implications, this uses the fact that echo is [defined in POSIX](https://www.man7.org/linux/man-pages/man1/echo.1p.html) with a very small feature set, and that piping is a simple shell feature. The presence of the `echo` command is recognized (as any shell might recognize it) and evaluated into stdin data.

Closes: https://github.com/assert-rs/snapbox/issues/172 (thus CC'ing @jpmckinney)

[edit: Add POSIX link]