### PR TITLE
Fix minimal versions dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     permissions:
       contents: none
     name: CI
-    needs: [test, msrv, lockfile, docs, rustfmt, clippy]
+    needs: [test, msrv, lockfile, docs, rustfmt, clippy, minimal-versions]
     runs-on: ubuntu-latest
     if: "always()"
     steps:
@@ -72,6 +72,27 @@ jobs:
       run: cargo hack check --all-features --locked --rust-version --ignore-private --workspace --all-targets
     - name: No-default features
       run: cargo hack check --no-default-features --locked --rust-version --ignore-private --workspace --all-targets
+  # Make sure the library builds with all dependencies downgraded to their
+  # oldest versions allowed by the semver spec. This ensures we have not
+  # under-specified any dependency
+  minimal-versions:
+    name: Minimal versions
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    - name: Install stable Rust
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        toolchain: stable
+    - name: Install nightly Rust
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        toolchain: nightly
+    - name: Downgrade dependencies to minimal versions
+      run: cargo +nightly generate-lockfile -Z minimal-versions
+    - name: Compile with minimal versions
+      run: cargo +stable check --workspace --all-features --all-targets --locked
   lockfile:
     runs-on: ubuntu-latest
     steps:

--- a/crates/snapbox/Cargo.toml
+++ b/crates/snapbox/Cargo.toml
@@ -76,7 +76,7 @@ content_inspector = { version = "0.2.4", optional = true }
 tempfile = { version = "3.0", optional = true }
 walkdir = { version = "2.3.2", optional = true }
 dunce = { version = "1.0", optional = true }
-filetime = { version = "0.2", optional = true }
+filetime = { version = "0.2.8", optional = true }
 
 os_pipe = { version = "1.0", optional = true }
 wait-timeout = { version = "0.2.0", optional = true }

--- a/crates/trycmd/Cargo.toml
+++ b/crates/trycmd/Cargo.toml
@@ -61,7 +61,7 @@ humantime-serde = "1"
 toml_edit = { version = "0.22.13", features = ["serde"] }
 escargot = { version = "0.5.7", optional = true }
 
-schemars = { version = "0.8.3", features = ["preserve_order"], optional = true }
+schemars = { version = "0.8.9", features = ["preserve_order"], optional = true }
 serde_json = { version = "1.0", optional = true }
 
 [lints]

--- a/crates/tryfn/Cargo.toml
+++ b/crates/tryfn/Cargo.toml
@@ -37,4 +37,4 @@ color-auto = ["snapbox/color-auto"]
 [dependencies]
 snapbox = { path = "../snapbox", version = "0.6.10", default-features = false }
 libtest-mimic = "0.7.0"
-ignore = "0.4"
+ignore = "0.4.11"


### PR DESCRIPTION
The CI job I added in this PR is something I try to run on all my crates as well. It's something that catch if the crate (or a transitive dependency) has under-specified a dependency.

`cargo +nightly update -Z minimal-versions` downgrades the entire dependency tree to the lowest allowed versions according to all the dependency semver specs in their `Cargo.toml` files.

It's very common to just add `foo = "0.3"` manually and then write code and run. Not realizing cargo automatically pulls in the latest version at the time. That might be `foo 0.3.8` and you might unknowingly depend on features introduced in `foo 0.3.4`. A CI check like this makes sure you don't under-specify version requirements like that.

I found this because I depend on `trycmd` and this became an error with `filetime`. See this CI run: https://github.com/mullvad/unicop/actions/runs/9709586296/job/26798567031?pr=2. You depend on `filetime::set_file_mtime`, but that was introduced in `filetime 0.2.6`. However, I had to bump the version even further, because `filetime` did not build with minimal versions until `0.2.8`.