### PR TITLE
Replace humantime dependency for jiff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,22 +410,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
-name = "humantime-serde"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
-dependencies = [
- "humantime",
- "serde",
-]
-
-[[package]]
 name = "ignore"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -488,6 +472,28 @@ name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+
+[[package]]
+name = "jiff"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d699bc6dfc879fb1bf9bdff0d4c56f0884fc6f0d0eb0fba397a6d00cd9a6b85e"
+dependencies = [
+ "jiff-static",
+ "portable-atomic",
+ "portable-atomic-util",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d16e75759ee0aa64c57a56acbf43916987b20c77373cb7e808979e02b93c9f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "lazy_static"
@@ -588,19 +594,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.82"
+name = "portable-atomic"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ad3d49ab951a01fbaafe34f2ec74122942fe18a3f9814c3268f1bb72042131b"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -730,18 +751,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.202"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "226b61a0d411b2ba5ff6d7f73a476ac4f8bb900373459cd00fab8512828ba395"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.202"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6048858004bcff69094cd972ed40a32500f153bd3be9f716b2eed2e8217c4838"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -834,9 +855,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "2.0.63"
+version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf5be731623ca1a1fb7d8be6f261a3be6d3e2337b8a1f97be944d020c8fcb704"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -913,8 +934,7 @@ dependencies = [
  "automod",
  "escargot",
  "glob",
- "humantime",
- "humantime-serde",
+ "jiff",
  "rayon",
  "schemars",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "2"
 repository = "https://github.com/assert-rs/snapbox/"
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.65"  # MSRV
+rust-version = "1.70"  # MSRV
 include = [
   "build.rs",
   "src/**/*",

--- a/crates/trycmd/Cargo.toml
+++ b/crates/trycmd/Cargo.toml
@@ -55,8 +55,7 @@ rayon = "1.5.1"
 
 serde = { version = "1.0", features = ["derive"] }
 shlex = "1.1.0"
-humantime = "2"
-humantime-serde = "1"
+jiff = { version = "0.2.4", default-features = false }
 toml_edit = { version = "0.22.13", features = ["serde"] }
 escargot = { version = "0.5.13", optional = true }
 

--- a/crates/trycmd/src/runner.rs
+++ b/crates/trycmd/src/runner.rs
@@ -11,6 +11,7 @@ use std::eprintln;
 #[cfg(not(feature = "color"))]
 use std::io::stderr;
 
+use jiff::SignedDuration;
 use rayon::prelude::*;
 use snapbox::data::DataFormat;
 use snapbox::dir::FileType;
@@ -68,10 +69,11 @@ impl Runner {
                                         status.spawn.status.summary(),
                                     );
                                     if let Some(duration) = status.duration {
+                                        let duration = SignedDuration::try_from(duration).unwrap();
                                         let _ = write!(
                                             stderr,
                                             " {}",
-                                            palette.hint(humantime::format_duration(duration)),
+                                            palette.hint(format!("{duration:#}")),
                                         );
                                     }
                                     let _ = writeln!(stderr);
@@ -90,10 +92,11 @@ impl Runner {
                                         palette.error("failed"),
                                     );
                                     if let Some(duration) = status.duration {
+                                        let duration = SignedDuration::try_from(duration).unwrap();
                                         let _ = write!(
                                             stderr,
                                             " {}",
-                                            palette.hint(humantime::format_duration(duration)),
+                                            palette.hint(format!("{duration:#}")),
                                         );
                                     }
                                     let _ = writeln!(stderr);


### PR DESCRIPTION
Hello,

Just recently `humantime` was referenced as RUSTSEC. This PR replaces it with `jiff`

Solving https://github.com/rustsec/advisory-db/blob/a99f72f78f43ef5b7883126f5454d86d8670b97d/crates/humantime/RUSTSEC-2025-0014.md?plain=1#L4

Not sure if the parsing of this is covered by tests though